### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-circuitbreaker-demo-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/hystrixcircuitbreaker/HttpBinService.java
+++ b/spring-cloud-circuitbreaker-demo-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/hystrixcircuitbreaker/HttpBinService.java
@@ -33,12 +33,12 @@ public class HttpBinService {
 	}
 
 	public Map get() {
-		return rest.getForObject("http://httpbin.org/get", Map.class);
+		return rest.getForObject("https://httpbin.org/get", Map.class);
 
 	}
 
 	public Map delay(int seconds) {
-		return rest.getForObject("http://httpbin.org/delay/" + seconds, Map.class);
+		return rest.getForObject("https://httpbin.org/delay/" + seconds, Map.class);
 	}
 
 	public Supplier<Map> delaySuppplier(int seconds) {

--- a/spring-cloud-circuitbreaker-demo-reactive-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactivehystrixcircuitbreakerdemo/HttpBinService.java
+++ b/spring-cloud-circuitbreaker-demo-reactive-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactivehystrixcircuitbreakerdemo/HttpBinService.java
@@ -33,7 +33,7 @@ public class HttpBinService {
 	private WebClient rest;
 
 	public HttpBinService(WebClient.Builder builder) {
-		this.rest = builder.baseUrl("http://httpbin.org").build();
+		this.rest = builder.baseUrl("https://httpbin.org").build();
 	}
 
 	public Mono<Map> get() {
@@ -41,7 +41,7 @@ public class HttpBinService {
 	}
 
 	public Mono<Map> delay(int seconds) {
-		return this.rest.get().uri("http://httpbin.org/delay/{seconds}", seconds).retrieve().bodyToMono(Map.class);
+		return this.rest.get().uri("https://httpbin.org/delay/{seconds}", seconds).retrieve().bodyToMono(Map.class);
 	}
 
 	public Flux<String> fluxDelay(int seconds) {

--- a/spring-cloud-circuitbreaker-demo-reactive-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactiveresilience4jcircuitbreakerdemo/HttpBinService.java
+++ b/spring-cloud-circuitbreaker-demo-reactive-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactiveresilience4jcircuitbreakerdemo/HttpBinService.java
@@ -34,7 +34,7 @@ public class HttpBinService {
 	private WebClient rest;
 
 	public HttpBinService(WebClient.Builder builder) {
-		this.rest = builder.baseUrl("http://httpbin.org").build();
+		this.rest = builder.baseUrl("https://httpbin.org").build();
 	}
 
 	public Mono<Map> get() {

--- a/spring-cloud-circuitbreaker-demo-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/resilience4jcircuitbreakerdemo/HttpBinService.java
+++ b/spring-cloud-circuitbreaker-demo-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/resilience4jcircuitbreakerdemo/HttpBinService.java
@@ -33,12 +33,12 @@ public class HttpBinService {
 	}
 
 	public Map get() {
-		return rest.getForObject("http://httpbin.org/get", Map.class);
+		return rest.getForObject("https://httpbin.org/get", Map.class);
 
 	}
 
 	public Map delay(int seconds) {
-		return rest.getForObject("http://httpbin.org/delay/" + seconds, Map.class);
+		return rest.getForObject("https://httpbin.org/delay/" + seconds, Map.class);
 	}
 
 	public Supplier<Map> delaySuppplier(int seconds) {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://httpbin.org/delay/ (404) with 3 occurrences migrated to:  
  https://httpbin.org/delay/ ([https](https://httpbin.org/delay/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://httpbin.org with 2 occurrences migrated to:  
  https://httpbin.org ([https](https://httpbin.org) result 200).
* [ ] http://httpbin.org/get with 2 occurrences migrated to:  
  https://httpbin.org/get ([https](https://httpbin.org/get) result 200).