### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/hystrixcircuitbreaker/DemoController.java
+++ b/spring-cloud-circuitbreaker-demo-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/hystrixcircuitbreaker/DemoController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/hystrixcircuitbreaker/HttpBinService.java
+++ b/spring-cloud-circuitbreaker-demo-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/hystrixcircuitbreaker/HttpBinService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/hystrixcircuitbreaker/HystrixCircuitbreakerDemoApplication.java
+++ b/spring-cloud-circuitbreaker-demo-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/hystrixcircuitbreaker/HystrixCircuitbreakerDemoApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/demo/hystrixcircuitbreaker/HystrixCircuitbreakerDemoApplicationTests.java
+++ b/spring-cloud-circuitbreaker-demo-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/demo/hystrixcircuitbreaker/HystrixCircuitbreakerDemoApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-reactive-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactivehystrixcircuitbreakerdemo/DemoController.java
+++ b/spring-cloud-circuitbreaker-demo-reactive-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactivehystrixcircuitbreakerdemo/DemoController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-reactive-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactivehystrixcircuitbreakerdemo/HttpBinService.java
+++ b/spring-cloud-circuitbreaker-demo-reactive-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactivehystrixcircuitbreakerdemo/HttpBinService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-reactive-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactivehystrixcircuitbreakerdemo/ReactiveHystrixCircuitBreaker.java
+++ b/spring-cloud-circuitbreaker-demo-reactive-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactivehystrixcircuitbreakerdemo/ReactiveHystrixCircuitBreaker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-reactive-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactivehystrixcircuitbreakerdemo/ReactiveHystrixCircuitbreakerDemoApplication.java
+++ b/spring-cloud-circuitbreaker-demo-reactive-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactivehystrixcircuitbreakerdemo/ReactiveHystrixCircuitbreakerDemoApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-reactive-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactiveresilience4jcircuitbreakerdemo/DemoController.java
+++ b/spring-cloud-circuitbreaker-demo-reactive-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactiveresilience4jcircuitbreakerdemo/DemoController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-reactive-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactiveresilience4jcircuitbreakerdemo/HttpBinService.java
+++ b/spring-cloud-circuitbreaker-demo-reactive-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactiveresilience4jcircuitbreakerdemo/HttpBinService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-reactive-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactiveresilience4jcircuitbreakerdemo/ReactiveResilience4JCircuitbreakerDemoApplication.java
+++ b/spring-cloud-circuitbreaker-demo-reactive-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/reactiveresilience4jcircuitbreakerdemo/ReactiveResilience4JCircuitbreakerDemoApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/resilience4jcircuitbreakerdemo/DemoController.java
+++ b/spring-cloud-circuitbreaker-demo-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/resilience4jcircuitbreakerdemo/DemoController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/resilience4jcircuitbreakerdemo/HttpBinService.java
+++ b/spring-cloud-circuitbreaker-demo-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/resilience4jcircuitbreakerdemo/HttpBinService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-demo-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/resilience4jcircuitbreakerdemo/Resilience4JCircuitbreakerDemoApplication.java
+++ b/spring-cloud-circuitbreaker-demo-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/demo/resilience4jcircuitbreakerdemo/Resilience4JCircuitbreakerDemoApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 15 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).